### PR TITLE
Use Headers type where possible

### DIFF
--- a/lambda_handlers/handlers/http_handler.py
+++ b/lambda_handlers/handlers/http_handler.py
@@ -1,7 +1,7 @@
 """A handler for HTTP request events."""
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from lambda_handlers.types import Headers, APIGatewayProxyResult
 from lambda_handlers.errors import FormatError, NotFoundError, BadRequestError, ValidationError, ResultValidationError
@@ -78,7 +78,7 @@ class HTTPHandler(EventHandler):
         result.headers = self._create_headers(result.headers)
         return self.format_output(self.validate_result(result.asdict()))
 
-    def _create_headers(self, headers: Headers) -> Headers:
+    def _create_headers(self, headers: Optional[Headers]) -> Optional[Headers]:
         if not headers:
             headers = {}
 

--- a/lambda_handlers/response/cors_headers.py
+++ b/lambda_handlers/response/cors_headers.py
@@ -1,6 +1,6 @@
 """CORS Headers for responses."""
 
-from typing import Dict, Union
+from lambda_handlers.types import Headers
 
 
 class CORSHeaders:
@@ -10,9 +10,9 @@ class CORSHeaders:
         self.origin = origin or '*'
         self.credentials = credentials
 
-    def create_headers(self) -> Dict[str, Union[str, bool]]:
+    def create_headers(self) -> Headers:
         """Return the CORS-related parts of the response header."""
-        headers: Dict[str, Union[str, bool]] = {
+        headers: Headers = {
             'Access-Control-Allow-Origin': self.origin,
         }
         if self.credentials:

--- a/lambda_handlers/types.py
+++ b/lambda_handlers/types.py
@@ -3,7 +3,7 @@
 from typing import Any, Dict, Union, Optional
 from dataclasses import asdict, dataclass
 
-Headers = Optional[Dict[str, Union[str, bool, int]]]
+Headers = Dict[str, Union[str, bool, int]]
 
 
 @dataclass
@@ -12,8 +12,8 @@ class APIGatewayProxyResult:
 
     statusCode: int
     body: Union[str, Dict[str, Any]]
-    headers: Headers = None
-    multiValueHeaders: Headers = None
+    headers: Optional[Headers] = None
+    multiValueHeaders: Optional[Headers] = None
     isBase64Encoded: Optional[bool] = None
 
     def asdict(self) -> Dict[str, Any]:


### PR DESCRIPTION
## What did you implement:

This PR replaces all remaining header type references with a common type of `Headers`.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO