### PR TITLE
Add line to exclude tests folders

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include CHANGELOG.md
+recursive-exclude tests *


### PR DESCRIPTION
This PR adds a line in MANIFEST.in to exclude the tests folders from the distribution package.