### PR TITLE
fix(lambda_handler): gracefully handle None return values

### DIFF
--- a/lambda_handlers/handlers/http_handler.py
+++ b/lambda_handlers/handlers/http_handler.py
@@ -10,6 +10,7 @@ from lambda_handlers.handlers.event_handler import EventHandler
 from lambda_handlers.response.response_builder import (
     ok,
     not_found,
+    no_content,
     bad_request,
     bad_implementation,
     internal_server_error,
@@ -52,7 +53,9 @@ class HTTPHandler(EventHandler):
 
     def after(self, result):
         """Event method to be called just after the handler is executed."""
-        if not isinstance(result, APIGatewayProxyResult) and 'statusCode' not in result:
+        if result is None:
+            result = no_content()
+        elif not isinstance(result, APIGatewayProxyResult) and 'statusCode' not in result:
             result = ok(result)
         return self._create_response(result)
 
@@ -71,7 +74,8 @@ class HTTPHandler(EventHandler):
 
     def format_output(self, response):
         """Return `response` with a formatted `response['body']`."""
-        response['body'] = self._output_format.format(response['body'])
+        if 'body' in response:
+            response['body'] = self._output_format.format(response['body'])
         return response
 
     def _create_response(self, result: APIGatewayProxyResult) -> Dict[str, Any]:

--- a/lambda_handlers/handlers/tests/test_http_handler.py
+++ b/lambda_handlers/handlers/tests/test_http_handler.py
@@ -5,6 +5,7 @@ from lambda_handlers import validators
 from lambda_handlers.handlers import http_handler
 from lambda_handlers.response import cors
 from lambda_handlers.formatters.format import format
+from lambda_handlers.response.response_builder import no_content
 
 
 class TestHTTPHandlerDefaults:
@@ -117,6 +118,40 @@ class TestHTTPHandlerCustomOutputFormat:
 
         assert 'Content-Type' in response['headers']
         assert response['headers']['Content-Type'] == 'application/text+piped'
+
+
+class TestHTTPHandlerOutputFormatNoBodyDefault:
+
+    @pytest.fixture
+    def handler(self):
+        @http_handler()
+        def handler(event, context):
+            return None
+
+        return handler
+
+    def test_format_no_body(self, handler):
+        response = handler({}, None)
+        assert isinstance(response, dict)
+        assert response['statusCode'] == 204
+        assert 'body' not in response
+
+
+class TestHTTPHandlerOutputFormatNoBody:
+
+    @pytest.fixture
+    def handler(self):
+        @http_handler()
+        def handler(event, context):
+            return no_content()
+
+        return handler
+
+    def test_format_no_body(self, handler):
+        response = handler({}, None)
+        assert isinstance(response, dict)
+        assert response['statusCode'] == 204
+        assert 'body' not in response
 
 
 class TestHTTPHandlerCustomMarshmallowValidator:


### PR DESCRIPTION
This PR adds support to handle response dicts without `body` key gracefully.
Such behaviour is caused when a handler returns `None` or `no_content()`.