### PR TITLE
Move to materials theme, add pymdown extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,5 @@ node_modules
 .vscode
 .idea
 
-# Sphinx temp
-docs/_build
-docs/source
+# Mkdocs temp
+site

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ help:
 	@echo "isort - sort imports"
 	@echo "isort-check - check if your imports are correctly sorted"
 	@echo "build - create the distribution package"
+	@echo "docs - build the documentation pages"
+	@echo "docs-serve - build and serve locally the documentation pages"
 	@echo "release - package a release in wheel and tarball, requires twine"
+
 
 install:
 	python -m pip install pipenv
@@ -86,6 +89,12 @@ develop:
 coverage:
 	pytest --cov=hansel
 	coverage report -m
+
+docs:
+	tox -e docs
+
+docs-serve:
+	tox -e docs -- serve
 
 build:
 	python setup.py sdist bdist_wheel

--- a/docs/contributing/3.-code-of-conduct.md
+++ b/docs/contributing/3.-code-of-conduct.md
@@ -80,8 +80,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][https://www.contributor-covenant.org], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 mkdocs==1.0.4
-mkdocs-bootswatch==1.0
 mkdocs-markdownextradata-plugin==0.0.6
+mkdocs-material==4.4.3
+pymdown-extensions==6.1
+pygments==2.4.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: lambda-handlers
-theme: flatly
+# theme: flatly
+theme:
+  name: 'material'
 site_url: https://lambda-handlers.readthedocs.io
 repo_url: https://github.com/enter-at/lambda-handlers
 site_description: An opinionated Python package that facilitates specifying AWS Lambda handlers.
@@ -10,7 +12,31 @@ copyright: LICENSE
 plugins:
     - search
     - markdownextradata: {}
+markdown_extensions:
+  - toc:
+      permalink: true
+  - codehilite:
+      linenums: true
+  - pymdownx.arithmatex
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.critic
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:pymdownx.emoji.to_svg
+  - pymdownx.inlinehilite
+  - pymdownx.magiclink
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
 extra:
+  social:
+    - type: 'github'
+      link: 'https://github.com/enter-at'
   project:
     name: lambda-handlers
     docs_url: https://lambda-handlers.readthedocs.io

--- a/setup.cfg
+++ b/setup.cfg
@@ -142,6 +142,5 @@ commands =
 
 [testenv:docs]
 deps = -rdocs/requirements.txt
-changedir = {toxinidir}/docs
 commands =
-    sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    mkdocs {posargs:build}


### PR DESCRIPTION
This PR changes the docs theme to 'material' by using mkdocs-material.
Also, following the Materials theme docs, it adds some markdown extensions.
It also changes the tox settings for the `docs` target in setup.cfg to correctly generate the docs from the Makefile.